### PR TITLE
Add CompartmentLabel: estimator-agnostic structured compartment labeling

### DIFF
--- a/src/ossify/compartments.py
+++ b/src/ossify/compartments.py
@@ -35,12 +35,18 @@ from .algorithms import (
     smooth_features,
 )
 from .base import Cell
+from .structured_prediction import (
+    TransitionSchema,
+    absorb_small_compartments,
+    decode_tree,
+)
 
 __all__ = [
     "make_skel_prop_df",
     "make_skel_prop_df_base",
     "SkeletonVertexModel",
     "AxonLabel",
+    "CompartmentLabel",
     "get_models",
     "load_model_config",
     "MappedFeature",
@@ -846,3 +852,236 @@ class AxonLabel(SkeletonVertexModel):
             root_is_soma=root_is_soma,
             is_axon_seg=is_axon_seg,
         )
+
+
+# --- Structured-decode compartment classifier ------------------------------
+
+
+def _load_xgboost_classifier(filepath):
+    """Load a saved XGBoost classifier from ``filepath`` (booster JSON/UBJ)."""
+    import xgboost
+
+    model = xgboost.XGBClassifier()
+    model._estimator_type = "classifier"
+    model.load_model(filepath)
+    return model
+
+
+class CompartmentLabel(SkeletonVertexModel):
+    """Estimator-agnostic compartment labeler with an exact tree decode.
+
+    Mirrors :class:`AxonLabel` -- the shared ``extract -> score -> smooth ->
+    assign`` flow -- but replaces the segment-vote/root-component heuristic
+    ``assign`` with the principled structured-prediction tail: per-vertex class
+    probabilities become unaries, an exact tree-MAP :func:`decode_tree` applies
+    the :class:`~ossify.structured_prediction.TransitionSchema` priors, and an
+    optional :func:`~ossify.structured_prediction.absorb_small_compartments`
+    pass cleans up short, noise-driven label flips.
+
+    The per-vertex classifier is **any fitted estimator exposing
+    ``predict_proba``** (XGBoost, scikit-learn ``RandomForestClassifier``, ...).
+    Its ``classes_`` define the probability column order; ``schema.classes`` must
+    line up with that order, which the constructor validates.
+
+    Parameters
+    ----------
+    estimator : object
+        Fitted classifier with ``predict_proba(X) -> (n, K)``. Its ``classes_``
+        attribute (when present) sets the column order.
+    feature_columns : list of str
+        Columns of the extracted feature frame to feed the estimator, in the
+        order it was trained on.
+    schema : TransitionSchema
+        Declares the class names, transition priors, and ``default_cost``. There
+        is intentionally no default: a new estimator must declare its own priors.
+        ``schema.classes`` must match the estimator's class order (see above).
+    downstream_hops, upstream_hops, bidirectional_hops : int
+        Neighborhood-aggregation radii for feature extraction (must match how
+        the estimator was trained).
+    smooth_alpha : float, optional
+        If given, Laplacian-smooth the probabilities along the skeleton with this
+        alpha before decoding. Default ``None`` leaves the decoder's transition
+        costs to do the graph coupling.
+    absorb_min_size : int, optional
+        Absorb decoded compartments with this many vertices or fewer.
+    absorb_min_weight : float, optional
+        Absorb decoded compartments whose cable length (``half_edge_length``) is
+        this or less.
+    feature_spec : list of feature definitions, optional
+        See :func:`make_skel_prop_df`. Defaults to :data:`DEFAULT_FEATURE_SPEC`.
+    """
+
+    def __init__(
+        self,
+        estimator,
+        feature_columns: List[str],
+        schema: TransitionSchema,
+        *,
+        downstream_hops: int = 0,
+        upstream_hops: int = 0,
+        bidirectional_hops: int = 0,
+        smooth_alpha: Optional[float] = None,
+        absorb_min_size: Optional[int] = None,
+        absorb_min_weight: Optional[float] = None,
+        feature_spec: Optional[List[FeatureDef]] = None,
+    ):
+        self._estimator = estimator
+        self._feature_columns = list(feature_columns)
+        self._schema = schema
+        self._smooth_alpha = smooth_alpha
+        self._absorb_min_size = absorb_min_size
+        self._absorb_min_weight = absorb_min_weight
+        self._validate_classes()
+        super().__init__(
+            downstream_hops=downstream_hops,
+            upstream_hops=upstream_hops,
+            bidirectional_hops=bidirectional_hops,
+            feature_spec=feature_spec,
+        )
+
+    def _validate_classes(self) -> None:
+        """Check schema.classes lines up with the estimator's class order.
+
+        The estimator owns the column count and order (``predict_proba`` columns
+        follow ``classes_``). When ``classes_`` is just ``range(K)`` (or the
+        ``[False, True]`` placeholder), the schema supplies the names and only
+        the count is checked; when it carries meaningful labels, the order must
+        match exactly.
+        """
+        est_classes = getattr(self._estimator, "classes_", None)
+        if est_classes is None:
+            return  # validated against predict_proba width at score() time
+        est_classes = list(est_classes)
+        K = len(est_classes)
+        if len(self._schema.classes) != K:
+            raise ValueError(
+                f"schema has {len(self._schema.classes)} classes but the "
+                f"estimator predicts {K}."
+            )
+        if est_classes != list(range(K)) and est_classes != list(self._schema.classes):
+            raise ValueError(
+                f"estimator.classes_={est_classes} must match schema.classes="
+                f"{list(self._schema.classes)} in order; these define the "
+                "predict_proba column order the unaries inherit."
+            )
+
+    @property
+    def classes(self) -> tuple:
+        """Class labels, in unary/probability column order (from the schema)."""
+        return tuple(self._schema.classes)
+
+    @property
+    def schema(self) -> TransitionSchema:
+        return self._schema
+
+    @classmethod
+    def from_config(
+        cls,
+        schema: TransitionSchema,
+        config: Optional[Union[dict, str]] = None,
+        *,
+        smooth_alpha: Optional[float] = None,
+        absorb_min_size: Optional[int] = None,
+        absorb_min_weight: Optional[float] = None,
+        feature_spec: Optional[List[FeatureDef]] = None,
+    ) -> "CompartmentLabel":
+        """Build from a bundled XGBoost model config plus an explicit schema.
+
+        Loads the estimator, feature columns, and hop settings from a shipped
+        model config (see :func:`load_model_config`); ``schema`` is required
+        because the config carries no transition priors. ``smooth_alpha``
+        defaults to the config's ``spread_alpha`` when not overridden.
+        """
+        if not isinstance(config, dict):
+            config = load_model_config(config, dir=None)
+        if smooth_alpha is None:
+            smooth_alpha = config.get("spread_alpha")
+        return cls(
+            _load_xgboost_classifier(config["model_file"]),
+            config["feature_columns"],
+            schema,
+            downstream_hops=config.get("downstream_hops", 0),
+            upstream_hops=config.get("upstream_hops", 0),
+            bidirectional_hops=config.get("bidirectional_hops", 0),
+            smooth_alpha=smooth_alpha,
+            absorb_min_size=absorb_min_size,
+            absorb_min_weight=absorb_min_weight,
+            feature_spec=feature_spec,
+        )
+
+    # --- SkeletonVertexModel hooks -----------------------------------------
+
+    def score(self, features: pd.DataFrame) -> np.ndarray:
+        """Per-vertex class probabilities ``(n_vertices, K)`` from the estimator."""
+        proba = self._estimator.predict_proba(features[self._feature_columns].values)
+        if proba.shape[1] != len(self._schema.classes):
+            raise ValueError(
+                f"estimator returned {proba.shape[1]} probability columns but "
+                f"schema has {len(self._schema.classes)} classes."
+            )
+        return proba
+
+    def smooth(self, cell: Cell, scores: np.ndarray) -> np.ndarray:
+        """Optional Laplacian smoothing of probabilities; identity if no alpha."""
+        if self._smooth_alpha is None:
+            return scores
+        return smooth_features(
+            cell.skeleton, scores.astype(float), alpha=self._smooth_alpha
+        )
+
+    def _decode(self, cell: Cell, scores: np.ndarray):
+        """Decode (smoothed) probabilities to labels + per-edge violation costs."""
+        unaries = self.to_unaries(scores)
+        labels, edge_cost = decode_tree(
+            cell.skeleton, unaries, self._schema, return_labels_as="index"
+        )
+        if self._absorb_min_size is not None or self._absorb_min_weight is not None:
+            labels = absorb_small_compartments(
+                cell.skeleton,
+                labels,
+                min_size=self._absorb_min_size,
+                min_weight=self._absorb_min_weight,
+            )
+        return labels, edge_cost
+
+    def assign(self, cell: Cell, scores: np.ndarray) -> np.ndarray:
+        """Decode (+absorb) the scores into per-vertex class indices."""
+        labels, _ = self._decode(cell, scores)
+        return labels
+
+    def _run(self, cell: Cell):
+        """Full extract -> score -> smooth -> decode (+absorb) flow.
+
+        Returns ``(label_indices, edge_cost)``; the single path shared by
+        :meth:`predict` and :meth:`predict_with_violations`.
+        """
+        scores = self.smooth(cell, self.score(self.extract_features(cell)))
+        return self._decode(cell, scores)
+
+    # --- Domain API --------------------------------------------------------
+
+    def _as_labels(self, indices: np.ndarray, return_labels_as: str) -> np.ndarray:
+        if return_labels_as == "index":
+            return indices
+        if return_labels_as == "label":
+            return np.array(self._schema.classes, dtype=object)[indices]
+        raise ValueError("return_labels_as must be 'index' or 'label'.")
+
+    def predict(self, cell: Cell, return_labels_as: str = "label") -> np.ndarray:
+        """Per-vertex compartment labels via decode (+absorb).
+
+        ``return_labels_as`` is ``"label"`` (schema class labels, default) or
+        ``"index"`` (class indices).
+        """
+        labels, _ = self._run(cell)
+        return self._as_labels(labels, return_labels_as)
+
+    def predict_with_violations(self, cell: Cell, return_labels_as: str = "label"):
+        """Labels plus the per-edge transition cost paid to the parent.
+
+        Returns ``(labels, edge_cost)``; nonzero ``edge_cost`` entries are the
+        decoder's transition violations (a morphology QC signal). Costs are from
+        the decode, before any small-compartment absorption.
+        """
+        labels, edge_cost = self._run(cell)
+        return self._as_labels(labels, return_labels_as), edge_cost

--- a/src/ossify/structured_prediction.py
+++ b/src/ossify/structured_prediction.py
@@ -21,6 +21,8 @@ __all__ = [
     "TransitionSchema",
     "tree_map_decode",
     "decode_tree",
+    "tree_absorb_small_compartments",
+    "absorb_small_compartments",
 ]
 
 
@@ -41,8 +43,12 @@ class TransitionSchema:
     root_classes : sequence, optional
         Labels the root node is allowed to take. Defaults to all classes.
     default_cost : float
-        Cost for any transition not named in ``transitions``. Default 0.0
-        (endorsed).
+        Cost for any *label change* not named in ``transitions``. Default 0.0
+        (endorsed). Self-transitions are always free (diagonal forced to 0), so
+        a nonzero ``default_cost`` is a uniform switching penalty: a node needs
+        its unary advantage to exceed ``default_cost`` to flip away from its
+        parent's label. Acts as a total-variation regularizer on the number of
+        label changes over the tree.
     """
 
     def __init__(
@@ -77,9 +83,16 @@ class TransitionSchema:
 
     @property
     def cost_matrix(self) -> np.ndarray:
-        """``(K, K)`` matrix ``C[parent, child]`` of transition costs."""
+        """``(K, K)`` matrix ``C[parent, child]`` of transition costs.
+
+        Self-transitions (the diagonal) are 0 -- staying on a label is free --
+        so ``default_cost`` acts purely as a switching penalty on label
+        *changes*. An explicit ``(a, a)`` entry in ``transitions`` still
+        overrides its diagonal cell.
+        """
         K = self.n_classes
         C = np.full((K, K), self.default_cost, dtype=float)
+        np.fill_diagonal(C, 0.0)
         for (a, b), cost in self.transitions.items():
             C[self._index[a], self._index[b]] = float(cost)
         return C
@@ -222,3 +235,157 @@ def decode_tree(
     elif return_labels_as != "index":
         raise ValueError("return_labels_as must be 'index' or 'label'.")
     return labels, edge_cost
+
+
+def tree_absorb_small_compartments(
+    parent_array: np.ndarray,
+    root: int,
+    labels: np.ndarray,
+    min_size: Optional[int] = None,
+    node_weight: Optional[np.ndarray] = None,
+    min_weight: Optional[float] = None,
+) -> np.ndarray:
+    """Merge small same-label compartments into their parent's label.
+
+    A *compartment* is a maximal connected run of equally-labeled nodes on the
+    rooted tree -- its boundaries are exactly the edges where the label changes.
+    Any non-root compartment that is too small is relabeled to the label of the
+    node just above it (its parent compartment's label). This is a post-decode
+    cleanup for the short, noise-driven label flips a tree decode produces at
+    terminals and around skeletonization artifacts.
+
+    Two independent size criteria are offered; a compartment is absorbed if it
+    falls under *either* active threshold:
+
+    * ``min_size`` -- node count. A good tell for skeletonization/topology
+      artifacts, which show up as a few stray vertices regardless of scale.
+    * ``min_weight`` -- summed ``node_weight`` (e.g. path length). The
+      scale-aware criterion: how much evidence the compartment actually spans.
+
+    The rule is applied root-first to a fixpoint, so absorptions cascade: a
+    cleaned compartment can in turn absorb a child that has now become adjacent
+    to a different label. The root compartment has no parent and is never
+    changed.
+
+    Parameters
+    ----------
+    parent_array : np.ndarray
+        ``(n,)`` positional parent of each node; the root's parent is ``< 0``.
+    root : int
+        Positional index of the root node.
+    labels : np.ndarray
+        ``(n,)`` per-node labels (e.g. the output of :func:`tree_map_decode`).
+        Not modified in place.
+    min_size : int, optional
+        Absorb compartments with this many nodes or fewer.
+    node_weight : np.ndarray, optional
+        ``(n,)`` per-node weights (e.g. path length) summed to size a
+        compartment. Required when ``min_weight`` is given.
+    min_weight : float, optional
+        Absorb compartments whose summed ``node_weight`` is this or less.
+
+    Returns
+    -------
+    labels : np.ndarray
+        ``(n,)`` cleaned labels (a new array; the input is left untouched).
+    """
+    if min_size is None and min_weight is None:
+        raise ValueError("set min_size and/or min_weight.")
+    if min_weight is not None and node_weight is None:
+        raise ValueError("min_weight requires node_weight.")
+    parent_array = np.asarray(parent_array)
+    labels = np.asarray(labels).copy()
+    n = labels.shape[0]
+    if node_weight is not None:
+        node_weight = np.asarray(node_weight, dtype=float)
+
+    children: List[List[int]] = [[] for _ in range(n)]
+    for v in range(n):
+        p = parent_array[v]
+        if v != root and p >= 0:
+            children[p].append(v)
+
+    # Root-first order: every node precedes its descendants.
+    order: List[int] = []
+    stack = [root]
+    while stack:
+        v = stack.pop()
+        order.append(v)
+        stack.extend(children[v])
+
+    while True:
+        # Compartment id = top-most node of each maximal same-label run.
+        comp = np.empty(n, dtype=int)
+        for v in order:
+            p = parent_array[v]
+            if v == root or p < 0 or labels[p] != labels[v]:
+                comp[v] = v
+            else:
+                comp[v] = comp[p]
+
+        small = np.zeros(n, dtype=bool)  # indexed by compartment representative
+        if min_size is not None:
+            small |= np.bincount(comp, minlength=n) <= min_size
+        if min_weight is not None:
+            small |= np.bincount(comp, weights=node_weight, minlength=n) <= min_weight
+
+        # Root-first relabel: a small compartment takes its parent node's
+        # (already-updated) label, which cascades down the whole compartment.
+        changed = False
+        for v in order:
+            p = parent_array[v]
+            if v == root or p < 0 or not small[comp[v]]:
+                continue
+            if labels[v] != labels[p]:
+                labels[v] = labels[p]
+                changed = True
+        if not changed:
+            return labels
+
+
+def absorb_small_compartments(
+    skeleton,
+    labels: np.ndarray,
+    min_size: Optional[int] = None,
+    node_weight: Optional[np.ndarray] = None,
+    min_weight: Optional[float] = None,
+) -> np.ndarray:
+    """Clean small compartments on a skeleton/segment graph.
+
+    Thin wrapper over :func:`tree_absorb_small_compartments` that pulls topology
+    from a SkeletonLayer-like object (``parent_node_array``, ``root_positional``).
+    When ``min_weight`` is given without an explicit ``node_weight``, the
+    per-node weight defaults to ``skeleton.half_edge_length`` -- the per-vertex
+    cable length that sums to true cable length over a compartment -- so
+    ``min_weight`` reads directly as a cable-length threshold.
+
+    Parameters
+    ----------
+    skeleton : SkeletonLayer or SegmentGraph
+        Provides ``parent_node_array``, ``root_positional``, and (for the
+        ``min_weight`` default) ``half_edge_length``.
+    labels : np.ndarray
+        ``(n_nodes,)`` per-node labels (e.g. from :func:`decode_tree`).
+    min_size : int, optional
+        Absorb compartments with this many nodes or fewer.
+    node_weight : np.ndarray, optional
+        ``(n_nodes,)`` per-node weights. Defaults to ``skeleton.half_edge_length``
+        when ``min_weight`` is set and this is omitted.
+    min_weight : float, optional
+        Absorb compartments whose summed ``node_weight`` is this or less.
+
+    Returns
+    -------
+    labels : np.ndarray
+        ``(n_nodes,)`` cleaned labels (a new array).
+    """
+    if min_weight is not None and node_weight is None:
+        node_weight = skeleton.half_edge_length
+    return tree_absorb_small_compartments(
+        skeleton.parent_node_array,
+        skeleton.root_positional,
+        labels,
+        min_size=min_size,
+        node_weight=node_weight,
+        min_weight=min_weight,
+    )

--- a/tests/test_compartment_label.py
+++ b/tests/test_compartment_label.py
@@ -1,0 +1,178 @@
+"""Tests for ossify.compartments.CompartmentLabel.
+
+Decode/validation tests run with a tiny synthetic skeleton and a fake estimator
+(no ML framework or sample data needed). The end-to-end tests -- including the
+"any sklearn estimator" path -- are gated on the v1dd sample meshwork and the
+optional xgboost/sklearn extras.
+"""
+
+import pathlib
+
+import numpy as np
+import pytest
+
+from ossify import Cell
+from ossify.compartments import CompartmentLabel
+from ossify.structured_prediction import TransitionSchema
+
+DATA = pathlib.Path(__file__).parent / "data"
+MESHWORK = DATA / "v1dd_864691132533489754.h5"
+MODEL = "v1dd_ds15_us0_bd0.json"
+
+FEATURE_COLUMNS = [
+    "area_um2",
+    "vol_um3",
+    "max_dt_um",
+    "vol_to_area",
+    "syn_in",
+    "syn_out",
+    "down_area_um2",
+    "down_vol_um3",
+    "down_max_dt_um",
+    "down_vol_to_area",
+    "down_syn_in",
+    "down_syn_out",
+]
+
+
+class _FakeProba:
+    """Minimal sklearn-style classifier: fixed classes_, identity predict_proba."""
+
+    def __init__(self, classes):
+        self.classes_ = np.array(classes)
+
+    def predict_proba(self, X):
+        return np.asarray(X, dtype=float)
+
+
+def _schema(revert=50.0, default_cost=0.0):
+    return TransitionSchema(
+        classes=["dendrite", "axon"],
+        transitions={("axon", "dendrite"): revert},
+        root_classes=["dendrite"],
+        default_cost=default_cost,
+    )
+
+
+def _chain_cell(n=6):
+    verts = np.array([[i, 0, 0] for i in range(n)], dtype=float)
+    edges = np.column_stack([np.arange(1, n), np.arange(0, n - 1)])
+    cell = Cell()
+    cell.add_skeleton(verts, edges, root=0)
+    return cell
+
+
+class TestClassValidation:
+    def test_integer_placeholder_classes_ok(self):
+        m = CompartmentLabel(_FakeProba([0, 1]), ["f"], _schema())
+        assert m.classes == ("dendrite", "axon")
+
+    def test_bool_placeholder_classes_ok(self):
+        # [False, True] == [0, 1] -> treated as positional placeholders.
+        CompartmentLabel(_FakeProba([False, True]), ["f"], _schema())
+
+    def test_string_classes_must_match_order(self):
+        CompartmentLabel(_FakeProba(["dendrite", "axon"]), ["f"], _schema())
+        with pytest.raises(ValueError, match="must match schema.classes"):
+            CompartmentLabel(_FakeProba(["axon", "dendrite"]), ["f"], _schema())
+
+    def test_count_mismatch_raises(self):
+        with pytest.raises(ValueError, match="predicts 3"):
+            CompartmentLabel(_FakeProba([0, 1, 2]), ["f"], _schema())
+
+    def test_missing_classes_attr_is_allowed(self):
+        class NoClasses:
+            def predict_proba(self, X):
+                return np.asarray(X, dtype=float)
+
+        CompartmentLabel(NoClasses(), ["f"], _schema())  # validated at score()
+
+
+class TestDecodeTail:
+    def test_absorb_collapses_noisy_tip(self):
+        cell = _chain_cell(6)
+        scores = np.array([[0.99, 0.01]] * 4 + [[0.4, 0.6]] * 2)
+        on = CompartmentLabel(_FakeProba([0, 1]), ["f"], _schema(), absorb_min_size=2)
+        off = CompartmentLabel(_FakeProba([0, 1]), ["f"], _schema())
+        np.testing.assert_array_equal(on.assign(cell, scores), [0, 0, 0, 0, 0, 0])
+        np.testing.assert_array_equal(off.assign(cell, scores), [0, 0, 0, 0, 1, 1])
+
+    def test_default_cost_resists_trivial_flip(self):
+        cell = _chain_cell(4)
+        # a single weakly-axon leaf; with no switching penalty it flips...
+        scores = np.array([[0.99, 0.01]] * 3 + [[0.45, 0.55]])
+        weak = CompartmentLabel(_FakeProba([0, 1]), ["f"], _schema(default_cost=0.0))
+        np.testing.assert_array_equal(weak.assign(cell, scores), [0, 0, 0, 1])
+        # ...but a switching penalty larger than its log-odds pins it to dendrite.
+        firm = CompartmentLabel(_FakeProba([0, 1]), ["f"], _schema(default_cost=1.0))
+        np.testing.assert_array_equal(firm.assign(cell, scores), [0, 0, 0, 0])
+
+    def test_label_index_mapping(self):
+        cell = _chain_cell(4)
+        scores = np.array([[0.99, 0.01]] * 2 + [[0.1, 0.9]] * 2)
+        m = CompartmentLabel(_FakeProba([0, 1]), ["f"], _schema())
+        idx = m.assign(cell, scores)
+        np.testing.assert_array_equal(
+            m._as_labels(idx, "label"), ["dendrite", "dendrite", "axon", "axon"]
+        )
+        np.testing.assert_array_equal(m._as_labels(idx, "index"), idx)
+        with pytest.raises(ValueError):
+            m._as_labels(idx, "nonsense")
+
+
+# --- End-to-end on the real sample, incl. the "any sklearn model" path -------
+
+pytestmark_data = pytest.mark.skipif(
+    not MESHWORK.exists(), reason="v1dd sample meshwork not present"
+)
+
+
+@pytestmark_data
+def test_from_config_end_to_end():
+    pytest.importorskip("xgboost")
+    pytest.importorskip("h5py")
+    import ossify
+
+    cell, _ = ossify.import_legacy_meshwork(str(MESHWORK), as_pcg_skel=True)
+    schema = _schema(revert=10.0)
+    m = CompartmentLabel.from_config(schema, MODEL, absorb_min_size=3)
+    n = cell.skeleton.n_vertices
+
+    labels = m.predict(cell)
+    assert labels.shape == (n,)
+    assert set(np.unique(labels)).issubset({"dendrite", "axon"})
+
+    lab_idx, edge_cost = m.predict_with_violations(cell, return_labels_as="index")
+    assert lab_idx.shape == (n,) and edge_cost.shape == (n,)
+    assert lab_idx.dtype.kind in "iu"
+
+
+@pytestmark_data
+def test_accepts_plain_sklearn_estimator():
+    """Nothing is xgboost-specific: a sklearn RandomForest drops in unchanged."""
+    pytest.importorskip("xgboost")
+    pytest.importorskip("sklearn")
+    pytest.importorskip("h5py")
+    from sklearn.ensemble import RandomForestClassifier
+
+    import ossify
+    from ossify.compartments import AxonLabel, make_skel_prop_df
+
+    cell, _ = ossify.import_legacy_meshwork(str(MESHWORK), as_pcg_skel=True)
+    feats = make_skel_prop_df(cell, downstream_hops=15)
+    X = feats[FEATURE_COLUMNS].values
+    # supervise on the bundled model's mask just to obtain a fitted sklearn model
+    y = AxonLabel(MODEL).predict(cell).astype(int)
+    rf = RandomForestClassifier(n_estimators=20, random_state=0).fit(X, y)
+    assert list(rf.classes_) == [0, 1]  # positional placeholders; schema names them
+
+    m = CompartmentLabel(
+        rf,
+        FEATURE_COLUMNS,
+        _schema(revert=10.0),
+        downstream_hops=15,
+        absorb_min_size=3,
+    )
+    labels = m.predict(cell)
+    assert labels.shape == (cell.skeleton.n_vertices,)
+    assert set(np.unique(labels)).issubset({"dendrite", "axon"})

--- a/tests/test_structured_prediction.py
+++ b/tests/test_structured_prediction.py
@@ -6,7 +6,9 @@ import pytest
 from ossify import Cell
 from ossify.structured_prediction import (
     TransitionSchema,
+    absorb_small_compartments,
     decode_tree,
+    tree_absorb_small_compartments,
     tree_map_decode,
 )
 
@@ -52,6 +54,24 @@ class TestTransitionSchema:
         C = s.cost_matrix
         np.testing.assert_array_equal(C, [[0.0, 0.0], [100.0, 0.0]])
         np.testing.assert_array_equal(s.root_allowed_mask, [True, False])
+
+    def test_default_cost_is_switching_penalty(self):
+        # Nonzero default_cost penalizes label changes only; the diagonal
+        # (staying on a label) stays free, and explicit pairs still override.
+        s = TransitionSchema(
+            classes=["dendrite", "axon"],
+            transitions={("axon", "dendrite"): 100.0},
+            default_cost=3.0,
+        )
+        np.testing.assert_array_equal(s.cost_matrix, [[0.0, 3.0], [100.0, 0.0]])
+
+    def test_explicit_diagonal_overrides(self):
+        s = TransitionSchema(
+            classes=["a", "b"],
+            transitions={("a", "a"): 2.0},
+            default_cost=5.0,
+        )
+        np.testing.assert_array_equal(s.cost_matrix, [[2.0, 5.0], [5.0, 0.0]])
 
     def test_validation(self):
         with pytest.raises(ValueError):
@@ -183,3 +203,127 @@ class TestDecodeTreeWrapper:
         # broadcast a per-node labeling back to vertices
         per_vertex = sg.to_vertices(labels)
         assert per_vertex.shape[0] == cell.skeleton.n_vertices
+
+
+class TestAbsorbSmallCompartments:
+    def _chain(self, n):
+        # 0 -> 1 -> 2 -> ... -> n-1, rooted at 0
+        return np.array([-1] + list(range(n - 1))), 0
+
+    def test_terminal_island_absorbed_by_count(self):
+        # dendrite trunk with a 2-vertex axon tip; min_size=2 absorbs it.
+        parent, root = self._chain(6)
+        labels = np.array([0, 0, 0, 0, 1, 1])
+        out = tree_absorb_small_compartments(parent, root, labels, min_size=2)
+        np.testing.assert_array_equal(out, [0, 0, 0, 0, 0, 0])
+
+    def test_island_kept_when_above_threshold(self):
+        parent, root = self._chain(6)
+        labels = np.array([0, 0, 0, 0, 1, 1])
+        out = tree_absorb_small_compartments(parent, root, labels, min_size=1)
+        np.testing.assert_array_equal(out, labels)  # 2-vertex tip survives
+
+    def test_interior_island_absorbed(self):
+        # dendrite, one axon vertex in the middle, then dendrite again.
+        parent, root = self._chain(5)
+        labels = np.array([0, 0, 1, 0, 0])
+        out = tree_absorb_small_compartments(parent, root, labels, min_size=1)
+        np.testing.assert_array_equal(out, [0, 0, 0, 0, 0])
+
+    def test_input_not_mutated(self):
+        parent, root = self._chain(4)
+        labels = np.array([0, 0, 1, 1])
+        original = labels.copy()
+        tree_absorb_small_compartments(parent, root, labels, min_size=2)
+        np.testing.assert_array_equal(labels, original)
+
+    def test_root_compartment_never_changed(self):
+        # whole tree is a single small compartment; nothing to inherit.
+        parent, root = self._chain(3)
+        labels = np.array([1, 1, 1])
+        out = tree_absorb_small_compartments(parent, root, labels, min_size=10)
+        np.testing.assert_array_equal(out, [1, 1, 1])
+
+    def test_cascade_nested_islands(self):
+        # dend -> axon(1) -> soma(2); both small, both collapse to dendrite.
+        parent, root = self._chain(4)
+        labels = np.array([0, 1, 2, 2])  # comp sizes: {0:1, 1:1, 2:2}
+        out = tree_absorb_small_compartments(parent, root, labels, min_size=2)
+        np.testing.assert_array_equal(out, [0, 0, 0, 0])
+
+    def test_min_weight_uses_node_weight(self):
+        # 5 vertices but the axon tip spans little length -> absorbed by weight,
+        # while min_size alone (tip has 2 vertices) would need min_size>=2.
+        parent, root = self._chain(5)
+        labels = np.array([0, 0, 0, 1, 1])
+        weight = np.array([10.0, 10.0, 10.0, 0.4, 0.4])  # tip length 0.8
+        out = tree_absorb_small_compartments(
+            parent, root, labels, node_weight=weight, min_weight=1.0
+        )
+        np.testing.assert_array_equal(out, [0, 0, 0, 0, 0])
+
+    def test_either_threshold_triggers(self):
+        parent, root = self._chain(5)
+        labels = np.array([0, 0, 0, 1, 1])  # tip: 2 vertices, length 20
+        weight = np.array([1.0, 1.0, 1.0, 10.0, 10.0])
+        # min_size won't fire (tip has 2 > 1) but min_weight will not either
+        # (20 > 5); neither active threshold triggers -> unchanged.
+        out = tree_absorb_small_compartments(
+            parent, root, labels, min_size=1, node_weight=weight, min_weight=5.0
+        )
+        np.testing.assert_array_equal(out, labels)
+        # raising min_size to 2 trips the count criterion alone.
+        out2 = tree_absorb_small_compartments(
+            parent, root, labels, min_size=2, node_weight=weight, min_weight=5.0
+        )
+        np.testing.assert_array_equal(out2, [0, 0, 0, 0, 0])
+
+    def test_requires_a_threshold(self):
+        parent, root = self._chain(3)
+        labels = np.array([0, 1, 1])
+        with pytest.raises(ValueError):
+            tree_absorb_small_compartments(parent, root, labels)
+        with pytest.raises(ValueError):
+            tree_absorb_small_compartments(parent, root, labels, min_weight=1.0)
+
+
+class _WeightedFakeSkeleton(_FakeSkeleton):
+    def __init__(self, parent, root, half_edge_length):
+        super().__init__(parent, root)
+        self.half_edge_length = np.asarray(half_edge_length, dtype=float)
+
+
+class TestAbsorbSmallCompartmentsWrapper:
+    def _chain(self, n):
+        return np.array([-1] + list(range(n - 1))), 0
+
+    def test_pulls_topology_min_size_only(self):
+        # min_size alone needs no weights, so a plain skeleton is enough.
+        parent, root = self._chain(6)
+        skel = _FakeSkeleton(parent, root)
+        labels = np.array([0, 0, 0, 0, 1, 1])
+        out = absorb_small_compartments(skel, labels, min_size=2)
+        np.testing.assert_array_equal(out, [0, 0, 0, 0, 0, 0])
+
+    def test_min_weight_defaults_to_half_edge_length(self):
+        # short tip (cable 0.8) absorbed; the wrapper supplies half_edge_length.
+        parent, root = self._chain(5)
+        weight = np.array([10.0, 10.0, 10.0, 0.4, 0.4])
+        skel = _WeightedFakeSkeleton(parent, root, weight)
+        labels = np.array([0, 0, 0, 1, 1])
+        out = absorb_small_compartments(skel, labels, min_weight=1.0)
+        np.testing.assert_array_equal(out, [0, 0, 0, 0, 0])
+        # equivalent to passing the same weights explicitly
+        explicit = tree_absorb_small_compartments(
+            parent, root, labels, node_weight=weight, min_weight=1.0
+        )
+        np.testing.assert_array_equal(out, explicit)
+
+    def test_explicit_node_weight_overrides_default(self):
+        parent, root = self._chain(5)
+        skel = _WeightedFakeSkeleton(parent, root, np.full(5, 100.0))  # would keep
+        labels = np.array([0, 0, 0, 1, 1])
+        out = absorb_small_compartments(
+            skel, labels, node_weight=np.array([9, 9, 9, 0.4, 0.4]), min_weight=1.0
+        )
+        np.testing.assert_array_equal(out, [0, 0, 0, 0, 0])  # explicit weight wins

--- a/uv.lock
+++ b/uv.lock
@@ -1755,6 +1755,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "json5"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2542,6 +2551,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/3c/c4ef2164a71c1a63d7f1ae411c4082c5fa872405106db60a4b7114989ad7/narwhals-2.22.1.tar.gz", hash = "sha256:d62920805a0a43b7ff8b54b0c0d3142d796f8a9301836ada37e573d6a33cbcd9", size = 647493, upload-time = "2026-06-05T12:34:34.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl", hash = "sha256:60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53", size = 454815, upload-time = "2026-06-05T12:34:32.289Z" },
+]
+
+[[package]]
 name = "nbclient"
 version = "0.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2672,6 +2690,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-nccl-cu12"
+version = "2.30.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/8c/554bb020501d6c04ad8127d83f728137f8f9123f991666efbdcf9095a221/nvidia_nccl_cu12-2.30.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:03ecd776fd1d58fd2c9a0a687dcf8db9ecd0057382dba646fa3d65786d4a9ea1", size = 303277471, upload-time = "2026-06-09T03:24:16.327Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/e7ffa9c324ae260e5dbb4af2cd557bf7a8d155c8ac7b79a785fe1796fb92/nvidia_nccl_cu12-2.30.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:8ce1b8213f61f2bfac132e6df890af6450b77cbd140c6ce4e98cb0c2d8e678c9", size = 303361239, upload-time = "2026-06-09T03:24:53.816Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2751,6 +2778,11 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+compartments = [
+    { name = "scikit-learn" },
+    { name = "xgboost", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "xgboost", version = "3.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
 legacy = [
     { name = "h5py" },
 ]
@@ -2797,11 +2829,13 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.0.2" },
     { name = "orjson", specifier = ">=3.10.15" },
     { name = "pyvista", extras = ["jupyter"], marker = "extra == 'viz'", specifier = ">=0.46" },
+    { name = "scikit-learn", marker = "extra == 'compartments'", specifier = ">=1.3" },
     { name = "scipy", specifier = ">=1.15" },
     { name = "trame", marker = "extra == 'viz'", specifier = ">=3.10" },
     { name = "trimesh", specifier = ">=4.6.2" },
+    { name = "xgboost", marker = "extra == 'compartments'", specifier = ">=2.0" },
 ]
-provides-extras = ["legacy", "viz"]
+provides-extras = ["legacy", "compartments", "viz"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4154,6 +4188,51 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/e844fd9586e66540a15b71924d17a6cbc1bb749e81ddd0a796bcdba4c055/scikit_learn-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9db6f4d34e68c8899e4cab27fdf8eafe6ed21f2ba52ceb25ea250cd237f8e47b", size = 8789686, upload-time = "2026-06-02T11:53:05.439Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e2/ff880f62677a17d035817d543cb0fc8727d01eccbee81c5f7fc733a9d856/scikit_learn-1.9.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f401448645a3e7bc115aa3c094097865155b34bff1cba8101857d9104e99074c", size = 8256782, upload-time = "2026-06-02T11:53:08.904Z" },
+    { url = "https://files.pythonhosted.org/packages/25/64/eb40435e1a508ab1b4e284ce43ae80f6a162e5be5e38ed5a6fab467a9ea4/scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd3a8ef0c758555a3b23c03adaa858af32f7736785ded50ad5991f59c4ed03fa", size = 8992419, upload-time = "2026-06-02T11:53:11.551Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/4810a28e473185429e45a57eebcc91fc991b33d889cc0676063e671db03d/scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7e254636164090da847715a27f8e5478feb98c40a9e0ee90cbd277de9e5ceb8", size = 9281411, upload-time = "2026-06-02T11:53:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/67/be3d369f40d8178ba3bd86635d132e08cb5329b023e4669d9426d84bc007/scikit_learn-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:5dc1818c77575d149e25fce9ef82dd7b7263ae372f03494158668ad632a69759", size = 8272736, upload-time = "2026-06-02T11:53:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/37/79/a733f02dc2118da7e77a134b34f39f40201a353311b011d20859d2db3556/scikit_learn-1.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:366652351f092b219c248f1e72821e841960a63d8f358f1dcfd54dc1cbdbbc28", size = 7919564, upload-time = "2026-06-02T11:53:21.2Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/20/75f915ff375d6249e6550ac740fdbbd66159a068fd3af1400ff62036b07a/scikit_learn-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bd41b0d201bc81575531b96b713d3eb5e5f50fb0b82101ff0f92294fdc236ac", size = 8741122, upload-time = "2026-06-02T11:53:24.08Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d5/2b5148f2279196775e1db2aeb85d14b70ac80e7e32b3b28e7ebeafb0901d/scikit_learn-1.9.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5be45aa4a42a68a533913a6ed736cf309de2226411c79ef8d609a5456f1939b1", size = 8261512, upload-time = "2026-06-02T11:53:27.183Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ee/5adbc77656b71f9456a2f5a7a9fdb4bcf9207a6b962889f1c2f9323afa4e/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e50ed4da51974e86e940690e9a3d82e729b62b5a49f7c9bac534d515d39d86f", size = 8837603, upload-time = "2026-06-02T11:53:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8", size = 9132097, upload-time = "2026-06-02T11:53:33.456Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a4/c8e67227c680e2259c8864ae72ff48b06e16a6f51253a22167aa02a8aa4e/scikit_learn-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4306775fad04cc4b472a1b15af1ae9cede1540fbfcc17fbce3767cd8dc7ae283", size = 8211173, upload-time = "2026-06-02T11:53:36.602Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/3c0863792e98e67e9184aa4029288a175935eb65443afcd30d4f143450cf/scikit_learn-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:26e22435f63bcdcf396b574273f29f13dd531f5ea035801f5be10ba1540a4e60", size = 7867451, upload-time = "2026-06-02T11:53:39.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/c9a35cf59b20a86fec24d306f1547b78dec194b08d367ce2a3e4854169d9/scikit_learn-1.9.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9656acd4e93f74e0b66c8a36c88830a99252dfa900044d36bc2212ae89a47162", size = 8713289, upload-time = "2026-06-02T11:53:58.788Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a7/552a7821597c632b907f7bfe8f36f9f572777af8ef8a48353041cf8e091a/scikit_learn-1.9.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:24360002ae845e7866522b0a5bbf690802e7bc388cac8663502e78aa98598aa2", size = 8245141, upload-time = "2026-06-02T11:54:01.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/79/f4a0c4fe9711154cddabf913471153af79056382ddc612cfe5ee0ff4b72e/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5162ad10a418c8a282dde04c9aa06965de3e9a65f33c1440c0ae69bb1a09d913", size = 8847671, upload-time = "2026-06-02T11:54:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/4d72d9e475ac83719160c662619e4bf7b95c19507cd582e7d0167a3c3dae/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fea2cc5677ab49d6f5bade978c866da44957b712d92e9635e8b4f723013c3cb", size = 9118104, upload-time = "2026-06-02T11:54:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d5/6a58eea2cb9abbb9b3f2bb8b2cfb3243d1152d69f442d256c7af71304769/scikit_learn-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:64fa347efc1c839c487433e40c5144d38c336e8a2b59c81aa8660373945c2673", size = 8290674, upload-time = "2026-06-02T11:54:10.087Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5b/d4c879cf358f1187141cf90ced473f087183489090244f50c124a2ee478b/scikit_learn-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:1b944b6db288f6b926e3650026ddafb988929de95d11fc2cc5fa117773c9ba42", size = 7978807, upload-time = "2026-06-02T11:54:12.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/43/bfae3121ec67ae09150d453c442c7c1cc166e9aefe056e6ab3b7728a5cfc/scikit_learn-1.9.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4ccacf04ca5f4b492158a5f28afe0ace43f81b2571e4b9a66d34848b46128949", size = 9031941, upload-time = "2026-06-02T11:54:15.436Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b0/20a4546eb17f3b25d3c66df15810411c14ed5065bcfab50b53c96fb627b2/scikit_learn-1.9.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ee1a8db2c18c08e34c7412d4b10be1cac214cd4ea7dc9715a6a327eb49a37c96", size = 8613528, upload-time = "2026-06-02T11:54:18.842Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3c/e440e039bb82cd19004edaaad00acbde0fb9b461083c3ecf37941c557312/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:147e9329ef0e39f75d4cffa02b2aa48d827832684926cd5210d9a2cb5c57246b", size = 8855050, upload-time = "2026-06-02T11:54:21.699Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/b341b8dab5998da6270a3a42c2152c578501354d36f944b5856757035ef8/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a", size = 9097190, upload-time = "2026-06-02T11:54:24.454Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/de/b650b4d69b84468cfa2e28a3ff7b8103743029e6446ce1a97fe060ef688c/scikit_learn-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:78fc56eafd4edb9575d2d8950d1dd152061abb573341a1cb7e099fc40f6c6666", size = 8963204, upload-time = "2026-06-02T11:54:27.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/ff83d76d7418112e5a61326443cdda87be3545dd8d6599c95b2481a4419e/scikit_learn-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:051075bda8b7aab87b1906ab3d4740a1e1224a19d7b3781a576736edc94e76aa", size = 8222661, upload-time = "2026-06-02T11:54:30.192Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4328,6 +4407,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]
@@ -4690,6 +4778,54 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/06/8340b98693fe886af59a86b69ca0eb9f8095d6dbdd7a28496d9f3a8fb33f/wslink-2.5.6.tar.gz", hash = "sha256:12f3a6135cb3a74c4f1af758942c6a4b34a51fcb700839abfb91b13064a4244c", size = 29784, upload-time = "2026-03-12T00:35:26.018Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/26/d23eb1cc5c8f084d861bbb7035fa911ecb86be51810428dd6284398d021a/wslink-2.5.6-py3-none-any.whl", hash = "sha256:89f23bad3b3522dcb78be84907487f6cf742c6b4526a666fd3e4013f5f705015", size = 37165, upload-time = "2026-03-12T00:35:24.655Z" },
+]
+
+[[package]]
+name = "xgboost"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "nvidia-nccl-cu12", marker = "python_full_version < '3.12' and sys_platform == 'linux'" },
+    { name = "scipy", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/bb/1eb0242409d22db725d7a88088e6cfd6556829fb0736f9ff69aa9f1e9455/xgboost-3.2.0.tar.gz", hash = "sha256:99b0e9a2a64896cdaf509c5e46372d336c692406646d20f2af505003c0c5d70d", size = 1263936, upload-time = "2026-02-10T11:03:05.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/49/6e4cdd877c24adf56cb3586bc96d93d4dcd780b5ea1efb32e1ee0de08bae/xgboost-3.2.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:2f661966d3e322536d9c448090a870fcba1e32ee5760c10b7c46bac7a342079a", size = 2507014, upload-time = "2026-02-10T10:50:57.44Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f1/c09ef1add609453aa3ba5bafcd0d1c1a805c1263c0b60138ec968f8ec296/xgboost-3.2.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:eabbd40d474b8dbf6cb3536325f9150b9e6f0db32d18de9914fb3227d0bef5b7", size = 2328527, upload-time = "2026-02-10T10:51:17.502Z" },
+    { url = "https://files.pythonhosted.org/packages/96/9f/d9914a7b8df842832850b1a18e5f47aaa071c217cdd1da2ae9deb291018b/xgboost-3.2.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:852eabc6d3b3702a59bf78dbfdcd1cb9c4d3a3b6e5ed1f8781d8b9512354fdd2", size = 131100954, upload-time = "2026-02-10T11:02:42.704Z" },
+    { url = "https://files.pythonhosted.org/packages/79/98/679de17c2caa4fd3b0b4386ecf7377301702cb0afb22930a07c142fcb1d8/xgboost-3.2.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:99b4a6bbcb47212fec5cf5fbe12347215f073c08967431b0122cfbd1ee70312c", size = 131748579, upload-time = "2026-02-10T10:54:40.424Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1661dd114a914a67e3f7ab66fa1382e7599c2a8c340f314ad30a3e2b4d08/xgboost-3.2.0-py3-none-win_amd64.whl", hash = "sha256:0d169736fd836fc13646c7ab787167b3a8110351c2c6bc770c755ee1618f0442", size = 101681668, upload-time = "2026-02-10T10:59:31.202Z" },
+]
+
+[[package]]
+name = "xgboost"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "nvidia-nccl-cu12", marker = "python_full_version >= '3.12' and sys_platform == 'linux'" },
+    { name = "scipy", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/41/846d4de2b8fc694073fd3ac5052caf68caa1ea11cb7fa32d7ad9c049b232/xgboost-3.3.0.tar.gz", hash = "sha256:58bcb8a4cace648cdab7b94fa4f16d2c9ff26d90dd4d26907168106fa06d8746", size = 1224702, upload-time = "2026-06-17T21:26:50.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/72/3b68983c0215ef65d48e9eeb1f168c3c6e3d62a61ece605de3209c79cae1/xgboost-3.3.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:07688a377046b8640897b62421150bf73c6cc7101823474ec6ad08b93290f587", size = 2553505, upload-time = "2026-06-17T21:21:32.146Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/62/b49e756822b29909d0c95ed334662dc6c7c81a99ec6bc10dc18e69f3d6e7/xgboost-3.3.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:af7cea10f418b7c251ddc8da440f57bdab2990b5fc9f74a35a92b0f150ea287d", size = 2376040, upload-time = "2026-06-17T21:22:01.981Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/a0adcd1ee28f525bd5c9dc3ebe78a7599bf97c22866d6449f967b829e338/xgboost-3.3.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:624a83aeb1e7ba081719795db179f4ce6fff12e79de05cd9baf15ee48fd22f0e", size = 98180629, upload-time = "2026-06-17T21:24:00.804Z" },
+    { url = "https://files.pythonhosted.org/packages/47/1f/8b3e578cfd8e3bcdb4374e2bbe0b40b4e5320accb5cbdcf535ecc512eb5c/xgboost-3.3.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f59edaf28eccd1c519788607c72ed907ee6cedfa933d706620bc1612d24b354e", size = 98716607, upload-time = "2026-06-17T21:26:21.058Z" },
+    { url = "https://files.pythonhosted.org/packages/07/6b/087fd5d28fdbb90d385c50ee9308a820241b82feebdf42e72e19a48e4b32/xgboost-3.3.0-py3-none-win_amd64.whl", hash = "sha256:b06057f6a018fc04e6b3e0c15568ca636b8151a5b5f333478e500fcaf4fc7594", size = 69522696, upload-time = "2026-06-17T21:20:53.707Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Build out the structured-prediction tail of the compartment-labeling pipeline and a model class that uses it.

structured_prediction:
- TransitionSchema.cost_matrix now zeroes the diagonal, so default_cost is a symmetric switching penalty (total-variation regularizer on label changes) rather than a no-op; explicit self-transitions still override.
- Add absorb_small_compartments (skeleton wrapper, defaults node_weight to half_edge_length) and tree_absorb_small_compartments (array primitive): merge small same-label compartments into their parent by vertex count (min_size) and/or cable length (min_weight), root-first to a fixpoint.

compartments:
- Add CompartmentLabel(SkeletonVertexModel): score = any sklearn-style predict_proba estimator (xgboost, RandomForest, ...), assign = to_unaries -> decode_tree(schema) -> absorb_small_compartments. Required schema (no default); estimator owns class count/order, schema owns names/priors, validated at construction. from_config loads bundled xgboost models.